### PR TITLE
feat: load secrets from pass before .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# Secret retrieval: pass is consulted first for each key; .env overrides.
+# pass paths used by this project:
+#   api/ANTHROPIC              → ANTHROPIC_API_KEY
+#   oauth/GOOGLE_CLIENT_ID     → GOOGLE_CLIENT_ID
+#   oauth/GOOGLE_CLIENT_SECRET → GOOGLE_CLIENT_SECRET
+#   cv-pilot/SECRET_KEY        → SECRET_KEY
+#   api/JSEARCH                → JSEARCH_API_KEY
+
 # Google OAuth2 – create a project at https://console.cloud.google.com
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,10 +1,65 @@
 import os
+import subprocess
 from pathlib import Path
 
 from dotenv import load_dotenv
 
+
+def _get_pass(pass_path: str) -> str | None:
+    """Retrieve a secret from the pass store. Returns None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["pass", "show", pass_path],
+            capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _env_file_keys(env_path) -> set:
+    """Return variable names explicitly set in a .env file."""
+    keys = set()
+    try:
+        with open(env_path) as fh:
+            for line in fh:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    keys.add(line.split("=", 1)[0].strip())
+    except FileNotFoundError:
+        pass
+    return keys
+
+
+def _load_from_pass(mapping, env_file) -> None:
+    """Seed os.environ with secrets from pass.
+
+    Only loads a key if absent from both system environment and the .env file,
+    so that: system env > .env > pass
+    """
+    defined_in_file = _env_file_keys(env_file)
+    for env_var, pass_path in mapping.items():
+        if env_var in os.environ or env_var in defined_in_file:
+            continue
+        val = _get_pass(pass_path)
+        if val is not None:
+            os.environ[env_var] = val
+
+
+_DOTENV_PATH = Path(__file__).parent.parent / ".env"
+_load_from_pass(
+    {
+        "ANTHROPIC_API_KEY":    "api/ANTHROPIC",
+        "GOOGLE_CLIENT_ID":     "oauth/GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET": "oauth/GOOGLE_CLIENT_SECRET",
+        "SECRET_KEY":           "cv-pilot/SECRET_KEY",
+        "JSEARCH_API_KEY":      "api/JSEARCH",
+    },
+    _DOTENV_PATH,
+)
+
 # Load .env from project root (parent of backend/)
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(_DOTENV_PATH)
 
 GOOGLE_CLIENT_ID: str = os.environ.get("GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET: str = os.environ.get("GOOGLE_CLIENT_SECRET", "")


### PR DESCRIPTION
## Summary

Integrates `pass` (the standard Unix password manager) as a secrets source, with `.env` as an override layer.

**Priority order:** system env > `.env` > `pass`

- Before `load_dotenv()` runs, secrets are fetched from `pass` for any key not already present in the system environment or explicitly defined in the `.env` file.
- If a key is in `.env`, pass is not consulted for it — `.env` always wins over pass.
- If `pass` is unavailable or a path is missing, the app falls back to `.env` / defaults silently.

## pass paths used

| pass path | env var |
|---|---|
| `api/ANTHROPIC` | `ANTHROPIC_API_KEY` |
| `oauth/GOOGLE_CLIENT_ID` | `GOOGLE_CLIENT_ID` |
| `oauth/GOOGLE_CLIENT_SECRET` | `GOOGLE_CLIENT_SECRET` |
| `cv-pilot/SECRET_KEY` | `SECRET_KEY` |
| `api/JSEARCH` | `JSEARCH_API_KEY` |

This change covers all git worktrees of this repo (cv-pilot-ci-fix, cv-pilot-gdocs, cv-pilot-integration, cv-pilot-worktrees/*).

## Files changed
- `backend/config.py` — added `_get_pass`, `_env_file_keys`, `_load_from_pass` helpers + call site before `load_dotenv`
- `.env.example` — documents the pass paths